### PR TITLE
Fix docker sample error on windows

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,8 +27,8 @@ services:
       - RUNDECK_DATABASE_USERNAME=rundeck
       - RUNDECK_DATABASE_PASSWORD=rundeck123.
     volumes:
-      - ${PWD}/data/bastion_id_rsa:/home/rundeck/.ssh/bastion_id_rsa
-      - ${PWD}/data/node_id_rsa:/home/rundeck/.ssh/node_id_rsa
+      - ./data/bastion_id_rsa:/home/rundeck/.ssh/bastion_id_rsa
+      - ./data/node_id_rsa:/home/rundeck/.ssh/node_id_rsa
     networks:
       - rundeck
   rundeck-ops:
@@ -45,8 +45,8 @@ services:
       - CONFIG_SCRIPT_POSTSTART=scripts/import_project.sh
       - PROJECTS_LIST=OpenSSH-Bastiondemo
     volumes:
-      - ${PWD}/projects:/projects
-      - ${PWD}/data:/data
+      - ./projects:/projects
+      - ./data:/data
     networks:
       - rundeck
   bastion:
@@ -58,8 +58,8 @@ services:
       - linux-1
       - linux-2
     volumes:
-    - ${PWD}/data/bastion_id_rsa:/home/rundeck/.ssh/id_rsa
-    - ${PWD}/data/bastion_id_rsa.pub:/home/rundeck/.ssh/id_rsa.pub
+    - ./data/bastion_id_rsa:/home/rundeck/.ssh/id_rsa
+    - ./data/bastion_id_rsa.pub:/home/rundeck/.ssh/id_rsa.pub
     networks:
       - rundeck
       - bastion
@@ -71,8 +71,8 @@ services:
     environment:
       - SSHD_PORT=2223
     volumes:
-    - ${PWD}/data/node_id_rsa:/home/rundeck/.ssh/id_rsa
-    - ${PWD}/data/node_id_rsa.pub:/home/rundeck/.ssh/id_rsa.pub
+    - ./data/node_id_rsa:/home/rundeck/.ssh/id_rsa
+    - ./data/node_id_rsa.pub:/home/rundeck/.ssh/id_rsa.pub
     networks:
       - bastion
   linux-2:
@@ -81,8 +81,8 @@ services:
     ports:
       - "22"
     volumes:
-    - ${PWD}/data/node_id_rsa:/home/rundeck/.ssh/id_rsa
-    - ${PWD}/data/node_id_rsa.pub:/home/rundeck/.ssh/id_rsa.pub
+    - ./data/node_id_rsa:/home/rundeck/.ssh/id_rsa
+    - ./data/node_id_rsa.pub:/home/rundeck/.ssh/id_rsa.pub
     networks:
       - bastion
 volumes:

--- a/docker/rundeck/Dockerfile
+++ b/docker/rundeck/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get -y update && \
     zip
 
 #set rundeck password
+RUN groups | grep rundeck || groupadd rundeck && usermod -aG rundeck rundeck
 RUN echo 'rundeck:rundeck' | chpasswd
 
 USER rundeck


### PR DESCRIPTION
1. The base image has no group `rundeck`, so COPY command is failed on docker build.
    ```powershell
    PS openssh-bastion-node-execution\docker> docker-compose build rundeck
    Building rundeck
    Step 1/11 : FROM rundeck/rundeck:SNAPSHOT
    Step 2/11 : USER root
    Step 3/11 : RUN apt-get -y update &&     apt-get -y install     software-properties-common      apt-transport-https     iputils-ping     netcat-traditional     unzip     zip
    Step 4/11 : RUN echo 'rundeck:rundeck' | chpasswd
    Step 5/11 : USER rundeck
    Step 6/11 : ENV RDECK_BASE=/home/rundeck
    Step 7/11 : RUN mkdir data
    Step 8/11 : COPY --chown=rundeck:rundeck ./plugins ./libext
    ERROR: Service 'rundeck' failed to build: unable to convert uid/gid chown string to host mapping: can't find gid for group rundeck: no such group: rundeck
    ```
1. `${PWD}` can't use on Windows, so `docker-compose up -d` is failed.
    ```powershell
    PS openssh-bastion-node-execution\docker> docker-compose up -d
    WARNING: The PWD variable is not set. Defaulting to a blank string.
    Creating network "docker_rundeck" with driver "bridge"
    Creating network "docker_bastion" with driver "bridge"
    Creating docker_mysql_1   ... done
    Creating docker_linux-1_1 ... done
    Creating docker_linux-2_1 ... done
    Creating docker_bastion_1 ... done
    Creating docker_rundeck_1 ... done
    Creating docker_rundeck-ops_1 ... done

    PS openssh-bastion-node-execution\docker> docker-compose ps
    WARNING: The PWD variable is not set. Defaulting to a blank string.
            Name                      Command               State                  Ports
    ---------------------------------------------------------------------------------------------------
    docker_bastion_1       /bin/sh -c /usr/local/sbin ...   Exit 1
    docker_linux-1_1       /bin/sh -c /usr/local/sbin ...   Exit 1
    docker_linux-2_1       /bin/sh -c /usr/local/sbin ...   Exit 1
    docker_mysql_1         docker-entrypoint.sh mysqld      Up       0.0.0.0:32769->3306/tcp, 33060/tcp
    docker_rundeck-ops_1   /bin/sh -c scripts/run.sh        Exit 1
    docker_rundeck_1       docker-lib/entry.sh              Up       0.0.0.0:8080->4440/tcp
    ```

`docker-compse` can use relative path and use it.