### PR TITLE
Adding Per Node Bastion Host Option

### DIFF
--- a/contents/file-copier
+++ b/contents/file-copier
@@ -48,8 +48,14 @@ fi
 
 
 echo "$RD_CONFIG_SSH_CONFIG" > "$SSH_CONFIG_FILE_TMP"
-sed -e "s#@bastion_ssh_key@#$BASTION_IDENTITY_FILE#g" < "$SSH_CONFIG_FILE_TMP" > "$SSH_CONFIG_FILE"
 
+
+if [[ -n "${RD_CONFIG_BASTION_HOST:-}" ]]
+then
+    sed -e "s#@bastion_ssh_host@#$RD_CONFIG_BASTION_HOST#g" -e "s#@bastion_ssh_key@#$BASTION_IDENTITY_FILE#g" < "$SSH_CONFIG_FILE_TMP" > "$SSH_CONFIG_FILE"
+else
+    sed -e "s#@bastion_ssh_key@#$BASTION_IDENTITY_FILE#g" < "$SSH_CONFIG_FILE_TMP" > "$SSH_CONFIG_FILE"
+fi
 
 SSH_ARGS=($RD_CONFIG_SSH_OPTS -F "$SSH_CONFIG_FILE")
 [[ -n "${NODE_IDENTITY_FILE:-}" ]] && SSH_ARGS=(${SSH_ARGS[@]} -i "$NODE_IDENTITY_FILE")

--- a/contents/node-executor
+++ b/contents/node-executor
@@ -42,9 +42,14 @@ then
     NODE_IDENTITY_FILE="$SSH_NODE_KEY_FILE"
 fi
 
-
 echo "$RD_CONFIG_SSH_CONFIG" > "$SSH_CONFIG_FILE_TMP"
-sed -e "s#@bastion_ssh_key@#$BASTION_IDENTITY_FILE#g" < "$SSH_CONFIG_FILE_TMP" > "$SSH_CONFIG_FILE"
+
+if [[ -n "${RD_CONFIG_BASTION_HOST:-}" ]]
+then
+    sed -e "s#@bastion_ssh_host@#$RD_CONFIG_BASTION_HOST#g" -e "s#@bastion_ssh_key@#$BASTION_IDENTITY_FILE#g" < "$SSH_CONFIG_FILE_TMP" > "$SSH_CONFIG_FILE"
+else
+    sed -e "s#@bastion_ssh_key@#$BASTION_IDENTITY_FILE#g" < "$SSH_CONFIG_FILE_TMP" > "$SSH_CONFIG_FILE"
+fi
 
 
 SSH_ARGS=($RD_CONFIG_SSH_OPTS -F "$SSH_CONFIG_FILE")

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -22,6 +22,14 @@ providers:
       script-file: node-executor
       script-args: ${exec.command}
       config:
+        - name: bastion_host
+          title: Default Bastion Host.
+          type: String
+          required: false
+          description: 'Optional Default Bastion Host. You can overwrite this attribute at node level using ssh-bastion-host'
+          scope: Instance
+          renderingOptions:
+            instance-scope-node-attribute: "ssh-bastion-host"
         - name: bastion_ssh_key_storage_path
           title: Bastion SSH Key
           type: String
@@ -58,7 +66,7 @@ providers:
           title: 'Template ssh_config'
           type: String
           required: true
-          description: 'The SSH config template. Replace the "user@bastion" to match your needs.'
+          description: 'The SSH config template. Adjust the "user@bastion" to match your needs.'
           scope: Project          
           renderingOptions:
             displayType: CODE
@@ -67,7 +75,7 @@ providers:
               Host *
                 StrictHostKeyChecking no
                 Port 22
-                ProxyCommand ssh user@bastion -W %h:%p
+                ProxyCommand ssh user@@bastion_ssh_host@ -W %h:%p
                 IdentityFile @bastion_ssh_key@
         - name: dry_run
           title: 'Dry run?'
@@ -95,6 +103,14 @@ providers:
       script-file: file-copier
       script-args: ${file-copy.file} ${file-copy.destination} 
       config:
+        - name: bastion_host
+          title: Default Bastion Host.
+          type: String
+          required: false
+          description: 'Optional Default Bastion Host. You can overwrite this attribute at node level using ssh-bastion-host'
+          scope: Instance
+          renderingOptions:
+            instance-scope-node-attribute: "ssh-bastion-host"
         - name: bastion_ssh_key_storage_path
           title: Bastion SSH Key
           type: String
@@ -131,7 +147,7 @@ providers:
           title: ssh_config
           type: String
           required: true
-          description: 'The SSH config template. Replace the "user@bastion" to match your needs.'
+          description: 'The SSH config template. Adjust the "user@bastion" to match your needs.'
           scope: Project          
           renderingOptions:
             displayType: CODE
@@ -140,7 +156,7 @@ providers:
               Host *
                 StrictHostKeyChecking no
                 Port 22
-                ProxyCommand ssh user@bastion -W %h:%p
+                ProxyCommand ssh user@@bastion_ssh_host@ -W %h:%p
                 IdentityFile @bastion_ssh_key@
         - name: dry_run
           title: 'Dry run?'


### PR DESCRIPTION
 I wanted the bastion host to work on a node-attribute basis (so I could set up tags in AWS and just have everything ripple through rather than constantly having to adjust my SSH configuration script with a dynamic environment that has different bastions for different availability zones), therefore I've adjusted the plugin configuration to enable this as a possibility. In the instance where a node-attribute isn't specified then this can be set as a default parameter in the configuration, or additionally I believe I have retained backwards compatibility with custom-scripts that don't require this technique at all too.

